### PR TITLE
Linux fix for `make serve`, stop waiting for doc load to create render element.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,13 @@ test-w: ${NODE}
 
 build-module: src/*
 
+ifeq ($(PLATFORM), linux)
+serve:
+	google-chrome dist/index.html
+else
 serve:
 	open dist/index.html
+endif
 
 deploy: dist/*
 	deploy-s3.sh dist

--- a/client.js
+++ b/client.js
@@ -4,9 +4,10 @@ import constitutional from './src/constitutional';
 import components from './src/components';
 
 if (require.main === module) {
+  const element = renderElement(constitutional(), global.document);
+  
   global.window.onload = () => {
-    const element = renderElement(constitutional(), global.document);
-    const container = document.querySelector('#container')
+    const container = document.querySelector('#container');
     container.appendChild(element);
   };
 }


### PR DESCRIPTION
Branched `make serve` on platform. On linux, attempting `google-chrome dist/index.html` which looks like it should work. @lukebayes to confirm.

Also, no reason to wait for document load to create Nomplate dom elements. Just need the document to be loaded for subsequent append. Good to remember going forward.